### PR TITLE
Allow shackle-default-size to be a function.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,9 @@ The following key-value pairs are available:
   floating point value between 0 and 1.  A value of 0.33 for example
   would make it occupy a third of the original window's size.
   Alternatively you can use an integer value of 1 or greater to
-  display a window of the specified width or height instead.
+  display a window of the specified width or height instead. If a
+  function is specified, it is called with zero arguments and must
+  return a number of the above two types.
 
 - ``:frame`` and ``t``:
 

--- a/shackle.el
+++ b/shackle.el
@@ -86,8 +86,11 @@ determine side, must return one of the above four values."
   "Default size of aligned windows.
 A floating point number between 0 and 1 is interpreted as a
 ratio.  An integer equal or greater than 1 is interpreted as a
-number of lines."
-  :type 'number
+number of lines. If a function is specified, it is called with
+zero arguments and must return a number of the above two types."
+  :type '(choice (integer :tag "Number of lines")
+                 (float :tag "Number of lines (ratio)")
+                 (function :tag "Custom"))
   :group 'shackle)
 
 (defcustom shackle-rules nil
@@ -397,7 +400,9 @@ the :size key with a number value."
              (old-size (window-size (frame-root-window) horizontal))
              (size (or (plist-get plist :ratio) ; yey, backwards compatibility
                        (plist-get plist :size)
-                       shackle-default-size))
+                       (if (functionp shackle-default-size)
+                           (funcall shackle-default-size)
+                         shackle-default-size)))
              (new-size (round (if (>= size 1)
                                   (- old-size size)
                                 (* (- 1 size) old-size)))))


### PR DESCRIPTION
Allow shackle-default-size to be a function.

Use case: When I'm using a full screen frame, I'd like to split the window on the right side with size `0.33`. When I'm using a half horizontal screen frame, I'd like to split the window on the bottom size with size `0.42`. So I use something like `(setq shackle-default-size #'(lambda () (if (> (window-width) split-width-threshold) 0.33 0.42)))`. Doing so fits my screen and window size quite well.

<img width="832" alt="Screen Shot 2019-07-01 at 6 30 05 PM" src="https://user-images.githubusercontent.com/16749790/60430002-e3747680-9c2e-11e9-92bc-175e3db418ae.png">
<img width="1552" alt="Screen Shot 2019-07-01 at 6 33 47 PM" src="https://user-images.githubusercontent.com/16749790/60430003-e3747680-9c2e-11e9-8166-da8753eeea87.png">
